### PR TITLE
Add styled-components dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "react-d3-speedometer": "^1.0.1",
     "react-data-table-component": "^6.11.7",
     "react-dom": "^16.13.1",
-    "react-router": "6.0.0-beta.0"
+    "react-router": "6.0.0-beta.0",
+    "styled-components": "^5.3.1"
   },
   "devDependencies": {
     "@backstage/cli": "^0.7.9",


### PR DESCRIPTION
When I integrated the plugin into Backstage, it failed in the browser with this error:

```
Compiled with problems:

Error:

Module not found: Error: Can&apos;t resolve &apos;styled-components&apos; in &apos;D:\workspaces\roadie\backstage\node_modules\react-data-table-component\dist&apos;
```

To fix this, I had to explicitly add the `styled-components` package to the Backstage frontend app's package.json. Apparently the `react-data-table-component` that you are using requires `styled-components` to be installed but does not include it in its package.json [according to this](https://react-data-table-component.netlify.app/?path=/docs/getting-started-installation--page). 

Maybe you followed the same pattern intentionally?