### PR TITLE
Improve handling of multilevel repositories

### DIFF
--- a/src/components/HarborDashboardPage.tsx
+++ b/src/components/HarborDashboardPage.tsx
@@ -9,9 +9,12 @@ export const HarborDashboardPage = ({ entity }: { entity: Entity }) => {
   const { repositorySlug } = useHarborAppData({ entity });
   const info = repositorySlug.split("/");
 
+  const project = info.shift() as "string";
+  const repository = info.join("/");
+
   return (
     <InfoCard title="Harbor Dashboard">
-      <HarborRepository project={info[0]} repository={info[1]} widget={false} />
+      <HarborRepository project={project} repository={repository} widget={false} />
     </InfoCard>
   );
 };

--- a/src/components/HarborWidget.tsx
+++ b/src/components/HarborWidget.tsx
@@ -14,10 +14,13 @@ const Widget = ({ entity }: { entity: Entity }) => {
   const { repositorySlug } = useHarborAppData({ entity });
   const info = repositorySlug.split("/");
 
+  const project = info.shift() as "string";
+  const repository = info.join("/");
+
   return (
     <Card>
       <CardHeader title="Docker Image" />
-      <HarborRepository project={info[0]} repository={info[1]} widget />
+      <HarborRepository project={project} repository={repository} widget />
     </Card>
   );
 };


### PR DESCRIPTION
This commits improves how multilevel repositories are handled, ie. the repository slug can now be specified as myproject/myteam/myimage

I'm having a hard time testing this locally (also opened https://github.com/BESTSELLER/backstage-plugin-harbor/issues/97). Did it by patching the local node module. The PR is small but needs some more testing.

This fixes https://github.com/BESTSELLER/backstage-plugin-harbor-backend/issues/5 in the backend-plugin