### PR TITLE
Downgrading react dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@backstage/plugin-catalog-react": "^0.6.3",
     "@backstage/theme": "^0.2.11",
     "@material-ui/core": "^4.11.0",
-    "react": "^17.0.2",
+    "react": "^16.14.0",
     "react-d3-speedometer": "^1.0.1",
     "react-data-table-component": "^6.11.7",
     "react-dom": "^17.0.2",


### PR DESCRIPTION
Downgrading react dependency because Backstage uses react version 16 and having this plugin running version 17 breaks it with this [error](https://reactjs.org/docs/error-decoder.html/?invariant=321).

Let's merge this and make a new release.