### PR TITLE
Move react to peer dependencies and include react 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,13 +28,15 @@
     "@backstage/plugin-catalog-react": "^0.6.3",
     "@backstage/theme": "^0.2.11",
     "@material-ui/core": "^4.11.0",
-    "react": "^16.14.0",
     "react-d3-speedometer": "^1.0.1",
     "react-data-table-component": "^6.11.7",
-    "react-dom": "^16.13.1",
     "react-router": "6.0.0-beta.0",
     "styled-components": "^5.3.1"
   },
+  "peerDependencies": {
+      "react": "^16.13.1 || ^17.0.0",
+      "react-dom": "^16.13.1 || ^17.0.0"
+    },
   "devDependencies": {
     "@backstage/cli": "^0.11.0",
     "@backstage/dev-utils": "^0.2.7",


### PR DESCRIPTION
Currently, `react` and `react-dom` are listed under `dependencies`, requiring the use of react 16. This will cause multiple versions of react to be installed if the installer is using 17, [which will throw an error](https://reactjs.org/warnings/invalid-hook-call-warning.html) as well as bloat the build.

Instead, they should be linked as peer dependencies with react 17 added, in order to allow reuse for the installer.