### PR TITLE
fix: incorrect default backend in local dev

### DIFF
--- a/src/components/HarborRepository/HarborRepository.tsx
+++ b/src/components/HarborRepository/HarborRepository.tsx
@@ -12,7 +12,7 @@ function HarborRepository(props: RepositoryProps) {
   const { loading } = useAsync(async () => {
     let backendUrl = window.location.origin
     if (backendUrl.includes('3000')) {
-      backendUrl = backendUrl.replace('3000', '7000')
+      backendUrl = backendUrl.replace('3000', '7007')
     }
     const response = await fetch(
       `${backendUrl}/api/harbor/artifacts?project=${props.project}&repository=${props.repository}`


### PR DESCRIPTION
This is probably not the best solution. We should probably look in the configuration to determine where the backend is located. At least this fixes the plugin against the default local backstage setup. This likely fixes #174 too.