### PR TITLE
Update backstage-cli commands and fix the variables assignment definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,14 +11,13 @@
     "types": "dist/index.d.ts"
   },
   "scripts": {
-    "build": "backstage-cli plugin:build",
-    "start": "backstage-cli plugin:serve",
-    "lint": "backstage-cli lint",
-    "test": "backstage-cli test",
-    "diff": "backstage-cli plugin:diff",
-    "prepack": "backstage-cli prepack",
-    "postpack": "backstage-cli postpack",
-    "clean": "backstage-cli clean"
+    "build": "backstage-cli package build",
+    "start": "backstage-cli package start",
+    "lint": "backstage-cli package lint",
+    "test": "backstage-cli package test",
+    "prepack": "backstage-cli package prepack",
+    "postpack": "backstage-cli package postpack",
+    "clean": "backstage-cli package clean"
   },
   "dependencies": {
     "@backstage/catalog-model": "^1.0.0",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -19,6 +19,7 @@ export type Options = {
 export class HarborApiClient implements harborApi {
   // @ts-ignore
   private readonly discoveryApi: DiscoveryApi
+  // @ts-ignore
   private readonly fetchApi: FetchApi
 
   constructor(options: Options) {

--- a/src/components/HarborDashboardPage/HarborDashboardPage.tsx
+++ b/src/components/HarborDashboardPage/HarborDashboardPage.tsx
@@ -12,8 +12,8 @@ export const HarborDashboardPage = () => {
     <Grid container spacing={3}>
       {repositorySlug.split(', ').map((slug) => {
         const info = slug.split('/')
-        const host: string = info.length > 2 ? info.shift() : ''
-        const project: string = info.shift()
+        const host: string = info.length > 2 ? info.shift() as string : ''
+        const project: string = info.shift() as string
         const repository: string = info.join('/')
 
         return (

--- a/src/components/HarborWidget/HarborWidget.tsx
+++ b/src/components/HarborWidget/HarborWidget.tsx
@@ -19,8 +19,8 @@ const Widget = ({ entity }: { entity: Entity }) => {
       <Grid container>
         {repositorySlug.split(', ').map((slug) => {
           const info = slug.split('/')
-          const host: string = info.length > 2 ? info.shift() : ''
-          const project: string = info.shift()
+          const host: string = info.length > 2 ? info.shift() as string : ''
+          const project: string = info.shift() as string
           const repository: string = info.join('/')
 
           return (


### PR DESCRIPTION
- scripts in `package.json` are outdated (no more working with `bacsktage-cli`
- running `yarn tsc` rises an error:
```
$ yarn tsc
yarn run v1.22.19
src/api/index.ts:22:20 - error TS6133: 'fetchApi' is declared but its value is never read.

22   private readonly fetchApi: FetchApi
                      ~~~~~~~~

src/components/HarborDashboardPage/HarborDashboardPage.tsx:15:15 - error TS2322: Type 'string | undefined' is not assignable to type 'string'.
  Type 'undefined' is not assignable to type 'string'.

15         const host: string = info.length > 2 ? info.shift() : ''
                 ~~~~

src/components/HarborDashboardPage/HarborDashboardPage.tsx:16:15 - error TS2322: Type 'string | undefined' is not assignable to type 'string'.
  Type 'undefined' is not assignable to type 'string'.

16         const project: string = info.shift()
                 ~~~~~~~

src/components/HarborWidget/HarborWidget.tsx:22:17 - error TS2322: Type 'string | undefined' is not assignable to type 'string'.
  Type 'undefined' is not assignable to type 'string'.

22           const host: string = info.length > 2 ? info.shift() : ''
                   ~~~~

src/components/HarborWidget/HarborWidget.tsx:23:17 - error TS2322: Type 'string | undefined' is not assignable to type 'string'.
  Type 'undefined' is not assignable to type 'string'.

23           const project: string = info.shift()

```