### PR TITLE
feat: Add publish workflows for npm packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: npm-publish
+on:
+  push:
+    branches:
+      - master
+jobs:
+  npm-publish:
+    name: npm-publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Publish if version has been updated
+      uses: pascalgn/npm-publish-action@1.3.9
+      with: 
+        tag_name: "v%s"
+        tag_message: "v%s"
+        create_tag: "true"
+        commit_pattern: "^Release (\\S+)"
+        workspace: "."
+        publish_command: "yarn"
+        publish_args: "--non-interactive"
+      env: 
+        GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }} 
+        NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Implemented the publishing workflow for npm packages using the `pascalgn/npm-publish-action`.

https://github.com/marketplace/actions/publish-to-npm


Requirements  -> 
1.) Access token and NPM_TOKEN 

How to use ->
Simply push a commit with the name 'Release v*.*'; this action will automatically create the tag and publish the workflow to the npm registry.

 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an automated workflow for publishing the Node.js package to npm upon version tagging in the master branch. This enhances the deployment process and ensures timely updates to users.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->